### PR TITLE
chore: promote h52 to version 0.0.15

### DIFF
--- a/config-root/namespaces/mydev/h52/h52-h52-deploy.yaml
+++ b/config-root/namespaces/mydev/h52/h52-h52-deploy.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: h52
-        image: "nexus-docker.saas-ops.finline.app/q1323829945/h52:0.0.14"
+        image: "nexus-docker.saas-ops.finline.app/q1323829945/h52:0.0.15"
         ports:
         - containerPort: 8080
         imagePullPolicy: IfNotPresent

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,7 +107,7 @@
 	    <tr>
 	      <td>h52</td>
 	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> h52</td>
-	      <td>0.0.14</td>
+	      <td>0.0.15</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -202,14 +202,14 @@
   path: helmfiles/mydev/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.14
+    appVersion: 0.0.15
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-12-12T01:25:31Z"
+    firstDeployed: "2022-12-12T01:47:48Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-12-12T01:25:31Z"
+    lastDeployed: "2022-12-12T01:47:48Z"
     name: h52
     releaseName: h52
     repositoryName: dev
     repositoryUrl: https://chartmuseum-jx.saas-ops.finline.app
     resourcePath: config-root/namespaces/mydev/h52
-    version: 0.0.14
+    version: 0.0.15

--- a/helmfiles/mydev/helmfile.yaml
+++ b/helmfiles/mydev/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://chartmuseum-jx.saas-ops.finline.app
 releases:
 - chart: dev/h52
-  version: 0.0.14
+  version: 0.0.15
   name: h52
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote h52 to version 0.0.15

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
