### PR TITLE
chore: promote cucumber-test to version 1670911938-beta

### DIFF
--- a/config-root/namespaces/mydev/cucumber-test/cucumber-test-cucumber-test-deploy.yaml
+++ b/config-root/namespaces/mydev/cucumber-test/cucumber-test-cucumber-test-deploy.yaml
@@ -1,0 +1,28 @@
+# Source: cucumber-test/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cucumber-test-cucumber-test
+  labels:
+    app: cucumber-test-cucumber-test
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'cucumber-test'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: mydev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cucumber-test-cucumber-test
+  template:
+    metadata:
+      labels:
+        app: cucumber-test-cucumber-test
+    spec:
+      containers:
+      - name: cucumber-test
+        image: "nexus-docker.saas-ops.finline.app/q1323829945/cucumber-test:1670911938-beta"
+        ports:
+        - containerPort: 8102
+        imagePullPolicy: Always

--- a/config-root/namespaces/mydev/cucumber-test/cucumber-test-ingress.yaml
+++ b/config-root/namespaces/mydev/cucumber-test/cucumber-test-ingress.yaml
@@ -1,0 +1,28 @@
+# Source: cucumber-test/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: 1000m
+    meta.helm.sh/release-name: 'cucumber-test'
+  name: cucumber-test
+  namespace: mydev
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: cucumber-test
+            port:
+              number: 8102
+        path: /
+    host: cucumber-test-mydev.saas-ops.finline.app
+  tls:
+  - hosts:
+    - cucumber-test-mydev.saas-ops.finline.app
+    secretName: "jx-privkey"

--- a/config-root/namespaces/mydev/cucumber-test/cucumber-test-svc.yaml
+++ b/config-root/namespaces/mydev/cucumber-test/cucumber-test-svc.yaml
@@ -1,0 +1,17 @@
+# Source: cucumber-test/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cucumber-test
+  annotations:
+    meta.helm.sh/release-name: 'cucumber-test'
+  namespace: mydev
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8102
+    targetPort: 8102
+  selector:
+    app: cucumber-test-cucumber-test

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,6 +111,13 @@
 	      <td></td>
 	      <td></td>
 	    </tr>
+    <tr>
+	      <td>cucumber-test</td>
+	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> cucumber-test</td>
+	      <td>1670911938-beta</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
 
   </tbody>
 </table>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -213,3 +213,15 @@
     repositoryUrl: https://chartmuseum-jx.saas-ops.finline.app
     resourcePath: config-root/namespaces/mydev/h52
     version: v2.3.3
+  - apiVersion: v1
+    appVersion: 1670911938-beta
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2022-12-13T06:22:44Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2022-12-13T06:22:44Z"
+    name: cucumber-test
+    releaseName: cucumber-test
+    repositoryName: dev
+    repositoryUrl: https://chartmuseum-jx.saas-ops.finline.app
+    resourcePath: config-root/namespaces/mydev/cucumber-test
+    version: 1670911938-beta

--- a/helmfiles/mydev/helmfile.yaml
+++ b/helmfiles/mydev/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/cucumber-test
   version: 1670911938-beta
   name: cucumber-test
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/mydev/helmfile.yaml
+++ b/helmfiles/mydev/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: h52
   values:
   - jx-values.yaml
+- chart: dev/cucumber-test
+  version: 1670911938-beta
+  name: cucumber-test
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote cucumber-test to version 1670911938-beta

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
