### PR TITLE
chore: promote cucumber-test to version 1670985726-beta

### DIFF
--- a/config-root/namespaces/mydev/cucumber-test/cucumber-test-cucumber-test-deploy.yaml
+++ b/config-root/namespaces/mydev/cucumber-test/cucumber-test-cucumber-test-deploy.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: cucumber-test
-        image: "nexus-docker.saas-ops.finline.app/q1323829945/cucumber-test:1670911938-beta"
+        image: "nexus-docker.saas-ops.finline.app/q1323829945/cucumber-test:1670985726-beta"
         ports:
         - containerPort: 8102
         imagePullPolicy: Always

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,7 +114,7 @@
     <tr>
 	      <td>cucumber-test</td>
 	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> cucumber-test</td>
-	      <td>1670911938-beta</td>
+	      <td>1670985726-beta</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -214,14 +214,14 @@
     resourcePath: config-root/namespaces/mydev/h52
     version: v2.3.3
   - apiVersion: v1
-    appVersion: 1670911938-beta
+    appVersion: 1670985726-beta
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-12-13T06:22:44Z"
+    firstDeployed: "2022-12-14T02:51:59Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-12-13T06:22:44Z"
+    lastDeployed: "2022-12-14T02:51:59Z"
     name: cucumber-test
     releaseName: cucumber-test
     repositoryName: dev
     repositoryUrl: https://chartmuseum-jx.saas-ops.finline.app
     resourcePath: config-root/namespaces/mydev/cucumber-test
-    version: 1670911938-beta
+    version: 1670985726-beta

--- a/helmfiles/mydev/helmfile.yaml
+++ b/helmfiles/mydev/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/cucumber-test
-  version: 1670911938-beta
+  version: 1670985726-beta
   name: cucumber-test
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote cucumber-test to version 1670985726-beta

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
