### PR TITLE
chore: promote cucumber-test to version 1670989116-beta

### DIFF
--- a/config-root/namespaces/mydev/cucumber-test/cucumber-test-cucumber-test-deploy.yaml
+++ b/config-root/namespaces/mydev/cucumber-test/cucumber-test-cucumber-test-deploy.yaml
@@ -19,10 +19,14 @@ spec:
     metadata:
       labels:
         app: cucumber-test-cucumber-test
+      annotations:
+        dapr.io/app-id: app-loan-management
+        dapr.io/app-port: "8071"
+        dapr.io/enabled: "true"
     spec:
       containers:
       - name: cucumber-test
-        image: "nexus-docker.saas-ops.finline.app/q1323829945/cucumber-test:1670986722-beta"
+        image: "nexus-docker.saas-ops.finline.app/q1323829945/cucumber-test:1670989116-beta"
         ports:
-        - containerPort: 8102
+        - containerPort: 8071
         imagePullPolicy: Always

--- a/config-root/namespaces/mydev/cucumber-test/cucumber-test-ingress.yaml
+++ b/config-root/namespaces/mydev/cucumber-test/cucumber-test-ingress.yaml
@@ -19,7 +19,7 @@ spec:
           service:
             name: cucumber-test
             port:
-              number: 8102
+              number: 8071
         path: /
     host: cucumber-test-mydev.saas-ops.finline.app
   tls:

--- a/config-root/namespaces/mydev/cucumber-test/cucumber-test-svc.yaml
+++ b/config-root/namespaces/mydev/cucumber-test/cucumber-test-svc.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: 8102
-    targetPort: 8102
+  - port: 8071
+    targetPort: 8071
   selector:
     app: cucumber-test-cucumber-test

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,7 +114,7 @@
     <tr>
 	      <td>cucumber-test</td>
 	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> cucumber-test</td>
-	      <td>1670986722-beta</td>
+	      <td>1670989116-beta</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -214,14 +214,14 @@
     resourcePath: config-root/namespaces/mydev/h52
     version: v2.3.3
   - apiVersion: v1
-    appVersion: 1670986722-beta
+    appVersion: 1670989116-beta
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-12-14T03:08:35Z"
+    firstDeployed: "2022-12-14T03:48:42Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-12-14T03:08:35Z"
+    lastDeployed: "2022-12-14T03:48:42Z"
     name: cucumber-test
     releaseName: cucumber-test
     repositoryName: dev
     repositoryUrl: https://chartmuseum-jx.saas-ops.finline.app
     resourcePath: config-root/namespaces/mydev/cucumber-test
-    version: 1670986722-beta
+    version: 1670989116-beta

--- a/helmfiles/mydev/helmfile.yaml
+++ b/helmfiles/mydev/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/cucumber-test
-  version: 1670986722-beta
+  version: 1670989116-beta
   name: cucumber-test
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote cucumber-test to version 1670989116-beta

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
