### PR TITLE
chore: promote h52 to version 0.1.7-SNAPSHOT

### DIFF
--- a/config-root/namespaces/mydev/h52/h52-h52-deploy.yaml
+++ b/config-root/namespaces/mydev/h52/h52-h52-deploy.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: h52
-        image: "nexus-docker.saas-ops.finline.app/q1323829945/h52:1.0.0-RELEASE"
+        image: "nexus-docker.saas-ops.finline.app/q1323829945/h52:0.1.7-SNAPSHOT"
         ports:
         - containerPort: 8080
         imagePullPolicy: Always

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,7 +107,7 @@
 	    <tr>
 	      <td>h52</td>
 	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> h52</td>
-	      <td>1.0.0-RELEASE</td>
+	      <td>0.1.7-SNAPSHOT</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -202,17 +202,17 @@
   path: helmfiles/mydev/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 1.0.0-RELEASE
+    appVersion: 0.1.7-SNAPSHOT
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-12-20T03:38:18Z"
+    firstDeployed: "2022-12-20T05:19:29Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-12-20T03:38:18Z"
+    lastDeployed: "2022-12-20T05:19:29Z"
     name: h52
     releaseName: h52
     repositoryName: dev
     repositoryUrl: https://chartmuseum-jx.saas-ops.finline.app
     resourcePath: config-root/namespaces/mydev/h52
-    version: 1.0.0-RELEASE
+    version: 0.1.7-SNAPSHOT
   - apiVersion: v1
     appVersion: 1671502205-SNAPSHOT
     description: A Helm chart for Kubernetes

--- a/helmfiles/mydev/helmfile.yaml
+++ b/helmfiles/mydev/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://chartmuseum-jx.saas-ops.finline.app
 releases:
 - chart: dev/h52
-  version: 1.0.0-RELEASE
+  version: 0.1.7-SNAPSHOT
   name: h52
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote h52 to version 0.1.7-SNAPSHOT

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
