### PR TITLE
chore: promote cucumber-test to version 0.0.2-SNAPSHOT

### DIFF
--- a/config-root/namespaces/mydev/cucumber-test/cucumber-test-cucumber-test-deploy.yaml
+++ b/config-root/namespaces/mydev/cucumber-test/cucumber-test-cucumber-test-deploy.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: cucumber-test
-        image: "nexus-docker.saas-ops.finline.app/q1323829945/cucumber-test:1671502205-SNAPSHOT"
+        image: "nexus-docker.saas-ops.finline.app/q1323829945/cucumber-test:0.0.2-SNAPSHOT"
         ports:
         - containerPort: 8071
         imagePullPolicy: Always

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,7 +114,7 @@
     <tr>
 	      <td>cucumber-test</td>
 	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> cucumber-test</td>
-	      <td>1671502205-SNAPSHOT</td>
+	      <td>0.0.2-SNAPSHOT</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -214,14 +214,14 @@
     resourcePath: config-root/namespaces/mydev/h52
     version: 1.0.1-RELEASE
   - apiVersion: v1
-    appVersion: 1671502205-SNAPSHOT
+    appVersion: 0.0.2-SNAPSHOT
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-12-20T02:18:58Z"
+    firstDeployed: "2022-12-20T05:54:30Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-12-20T02:18:58Z"
+    lastDeployed: "2022-12-20T05:54:30Z"
     name: cucumber-test
     releaseName: cucumber-test
     repositoryName: dev
     repositoryUrl: https://chartmuseum-jx.saas-ops.finline.app
     resourcePath: config-root/namespaces/mydev/cucumber-test
-    version: 1671502205-SNAPSHOT
+    version: 0.0.2-SNAPSHOT

--- a/helmfiles/mydev/helmfile.yaml
+++ b/helmfiles/mydev/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/cucumber-test
-  version: 1671502205-SNAPSHOT
+  version: 0.0.2-SNAPSHOT
   name: cucumber-test
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote cucumber-test to version 0.0.2-SNAPSHOT

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
